### PR TITLE
Fix broken tap syntax, def needed kwarg

### DIFF
--- a/lib/brew/gem/formula.rb.erb
+++ b/lib/brew/gem/formula.rb.erb
@@ -15,7 +15,7 @@ end
 class RubyGemsDownloadStrategy < AbstractDownloadStrategy
   include RubyBin
 
-  def fetch
+  def fetch(timeout: nil, **options)
     ohai "Fetching <%= name %> from gem source"
     cache.cd do
       ENV['GEM_SPEC_CACHE'] = "#{cache}/gem_spec_cache"


### PR DESCRIPTION
Fixes invalid syntax exception in tap
("def fetch")

Error: gem-XXXXX: Calling `def fetch`
in a subclass of `Formulary::
FormulaNamespaceYYYYYYYYYY::
RubyGemsDownloadStrategy` is disabled!
Use `def fetch(timeout: nil, **options)`
and output a warning when `options`
contains new unhandled options instead.